### PR TITLE
Updated refractor dependency and bumped version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refractor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1887,6 +1887,14 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/hast": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+      "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+      "requires": {
+        "@types/unist": "*"
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -4923,15 +4931,16 @@
       }
     },
     "hast-util-parse-selector": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
-      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ=="
     },
     "hastscript": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.2.tgz",
-      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
       "requires": {
+        "@types/hast": "^2.0.0",
         "comma-separated-tokens": "^1.0.0",
         "hast-util-parse-selector": "^2.0.0",
         "property-information": "^5.0.0",
@@ -8053,9 +8062,9 @@
       }
     },
     "prismjs": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
-      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -8119,9 +8128,9 @@
       }
     },
     "property-information": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
-      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
       "requires": {
         "xtend": "^4.0.0"
       }
@@ -8356,13 +8365,13 @@
       }
     },
     "refractor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.1.0.tgz",
-      "integrity": "sha512-bN8GvY6hpeXfC4SzWmYNQGLLF2ZakRDNBkgCL0vvl5hnpMrnyURk8Mv61v6pzn4/RBHzSWLp44SzMmVHqMGNww==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.3.0.tgz",
+      "integrity": "sha512-c/jEhQjk1NDyTF3hMgtu8PigaqkWUv+c5+mBffZCTnjyrNSJkG+0eoTOJV/u0XCTuPfaFzJyj6MM4HnF0Wr27Q==",
       "requires": {
-        "hastscript": "^5.0.0",
+        "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.21.0"
+        "prismjs": "~1.23.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refractor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Super-thin React wrapper for refractor (Syntax highlighting using VDOM)",
   "main": "lib/Refractor.js",
   "umd": "umd/Refractor.min.js",
@@ -45,7 +45,7 @@
   "homepage": "https://github.com/rexxars/react-refractor#readme",
   "dependencies": {
     "prop-types": "^15.6.1",
-    "refractor": "^3.1.0",
+    "refractor": "^3.3.0",
     "unist-util-filter": "^2.0.2",
     "unist-util-visit-parents": "^3.0.2"
   },


### PR DESCRIPTION
See https://github.com/wooorm/refractor/releases/tag/3.3.0 and https://github.com/PrismJS/prism/releases/tag/v1.23.0